### PR TITLE
Build hotfix

### DIFF
--- a/example/mainwindow.cpp
+++ b/example/mainwindow.cpp
@@ -837,7 +837,7 @@ void MainWindow::programmerActBt()
     programmer->show();
     pr_error = "";
     programmer->setTxt(pr_error);
-    programmer->setImg(FALSE);
+    programmer->setImg(false);
 
     //init ch341 programmer, get informations about this programmer
     ans_info = init_ch341();


### PR DESCRIPTION
mainwindow.cpp: In member function ‘void MainWindow::programmerActBt()’: mainwindow.cpp:840:24: error: ‘FALSE’ was not declared in this scope
  840 |     programmer->setImg(FALSE);