### PR TITLE
Correcting resources paths and setting the application window title

### DIFF
--- a/prog24.qrc
+++ b/prog24.qrc
@@ -1,16 +1,16 @@
 <RCC>
     <qresource prefix="/">
-        <file>resources/open.png</file>
-        <file>resources/save.png</file>
-        <file>resources/undo.png</file>
-        <file>resources/redo.png</file>
-        <file>resources/find.png</file>
-        <file>resources/qhexedit.ico</file>
-        <file>resources/read.png</file>
-        <file>resources/write.png</file>
-        <file>resources/chip_type.png</file>
-        <file>resources/ch341_to_form_150_150.png</file>
-        <file>resources/not_found.png</file>
-        <file>resources/24Cxx_icon64.ico</file>
+        <file alias="images/open.png">resources/open.png</file>
+        <file alias="images/save.png">resources/save.png</file>
+        <file alias="images/undo.png">resources/undo.png</file>
+        <file alias="images/redo.png">resources/redo.png</file>
+        <file alias="images/find.png">resources/find.png</file>
+        <file alias="images/qhexedit.ico">resources/qhexedit.ico</file>
+        <file alias="images/read.png">resources/read.png</file>
+        <file alias="images/write.png">resources/write.png</file>
+        <file alias="images/chip_type.png">resources/chip_type.png</file>
+        <file alias="images/ch341_to_form_150_150.png">resources/ch341_to_form_150_150.png</file>
+        <file alias="images/not_found.png">resources/not_found.png</file>
+        <file alias="images/24Cxx_icon64.ico">resources/24Cxx_icon64.ico</file>
     </qresource>
 </RCC>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -513,6 +513,8 @@ void MainWindow::init()
 
     setUnifiedTitleAndToolBarOnMac(true);
     hexEdit->setData(buf);
+
+    setWindowTitle("I2C EEPROM Programmer");
 }
 //
 int MainWindow::readActBt()


### PR DESCRIPTION
Hi @bigbigmdm , sorry for the delay, in this PR I'm adding a promised fix to return back the resources. I also assign application window a title, so it's not QHexEdit anymore.